### PR TITLE
[RDY] Test Repl and console client

### DIFF
--- a/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/Repl.java
+++ b/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/Repl.java
@@ -65,7 +65,7 @@ public final class Repl {
 
         String input;
         running = true;
-        while ((input = editor.getInput()) != null && running) {
+        while (running && (input = editor.getInput()) != null) {
             input = input.trim();
             if (input.length() == 0) {
                 continue;

--- a/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ReplModule.java
+++ b/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ReplModule.java
@@ -1,5 +1,6 @@
 package org.metaborg.spoofax.shell.client.console;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.function.Consumer;
@@ -12,10 +13,14 @@ import org.metaborg.spoofax.shell.commands.SpoofaxCommandInvoker;
 import org.metaborg.spoofax.shell.commands.StyledText;
 import org.metaborg.spoofax.shell.core.CoreModule;
 
+import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.name.Named;
 import com.google.inject.name.Names;
+
+import jline.console.ConsoleReader;
 
 /**
  * Bindings for Repl.
@@ -53,5 +58,25 @@ public class ReplModule extends CoreModule {
         configureUserInterface();
 
         bind(Repl.class).in(Singleton.class);
+    }
+
+    /**
+     * TODO: Replace with "CheckedProvides" because IO in Provider method is bad practice, see:
+     * https://github.com/google/guice/wiki/ThrowingProviders.
+     *
+     * @param in
+     *            The {@link InputStream}.
+     * @param out
+     *            The {@link OutputStream}.
+     * @return a {@link ConsoleReader} with the given streams.
+     * @throws IOException
+     *             When an IO error occurs upon construction.
+     */
+    @Provides
+    @Singleton
+    protected ConsoleReader provideConsoleReader(@Named("in") InputStream in,
+                                                 @Named("out") OutputStream out)
+                                                     throws IOException {
+        return new ConsoleReader(in, out);
     }
 }

--- a/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterface.java
+++ b/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterface.java
@@ -39,6 +39,8 @@ public class TerminalUserInterface implements IEditor, IDisplay {
     private PrintWriter err;
 
     /**
+     * @param reader
+     *            The jline2 {@link ConsoleReader} used to get input.
      * @param in
      *            The {@link InputStream} from which to read user input.
      * @param out
@@ -49,9 +51,9 @@ public class TerminalUserInterface implements IEditor, IDisplay {
      *             when an IO error occurs.
      */
     @Inject
-    public TerminalUserInterface(@Named("in") InputStream in, @Named("out") OutputStream out,
-        @Named("err") OutputStream err) throws IOException {
-        reader = new ConsoleReader(in, out);
+    public TerminalUserInterface(ConsoleReader reader, @Named("in") InputStream in,
+        @Named("out") OutputStream out, @Named("err") OutputStream err) throws IOException {
+        this.reader = reader;
         reader.setExpandEvents(false);
         reader.setHandleUserInterrupt(true);
         reader.setBellEnabled(true);

--- a/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterface.java
+++ b/shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterface.java
@@ -4,7 +4,6 @@ import static org.metaborg.spoofax.shell.client.console.AnsiColors.findClosest;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
@@ -41,8 +40,6 @@ public class TerminalUserInterface implements IEditor, IDisplay {
     /**
      * @param reader
      *            The jline2 {@link ConsoleReader} used to get input.
-     * @param in
-     *            The {@link InputStream} from which to read user input.
      * @param out
      *            The {@link PrintStream} to write results to.
      * @param err
@@ -51,8 +48,8 @@ public class TerminalUserInterface implements IEditor, IDisplay {
      *             when an IO error occurs.
      */
     @Inject
-    public TerminalUserInterface(ConsoleReader reader, @Named("in") InputStream in,
-        @Named("out") OutputStream out, @Named("err") OutputStream err) throws IOException {
+    public TerminalUserInterface(ConsoleReader reader, @Named("out") OutputStream out,
+                                 @Named("err") OutputStream err) throws IOException {
         this.reader = reader;
         reader.setExpandEvents(false);
         reader.setHandleUserInterrupt(true);

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/MockModule.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/MockModule.java
@@ -1,0 +1,43 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import org.metaborg.spoofax.shell.client.IEditor;
+import org.metaborg.spoofax.shell.commands.ICommandInvoker;
+
+import com.google.inject.AbstractModule;
+
+/**
+ * Allows for injecting mock {@link ICommandInvoker}s, for spying/verifying.
+ */
+public class MockModule extends AbstractModule {
+    private ICommandInvoker invokerMock;
+    private IEditor editorMock;
+
+    /**
+     * @param invokerMock
+     *            The mock {@link ICommandInvoker}.
+     */
+    public MockModule(ICommandInvoker invokerMock) {
+        this(invokerMock, null);
+    }
+    /**
+     * @param invokerMock
+     *            The mock {@link ICommandInvoker}.
+     * @param editorMock
+     *            The mock {@link IEditor}.
+     */
+    public MockModule(ICommandInvoker invokerMock, IEditor editorMock) {
+        this.invokerMock = invokerMock;
+        this.editorMock = editorMock;
+    }
+
+    @Override
+    protected void configure() {
+        if (invokerMock != null) {
+            bind(ICommandInvoker.class).toInstance(invokerMock);
+        }
+        if (editorMock != null) {
+            bind(IEditor.class).toInstance(editorMock);
+        }
+    }
+
+}

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/ReplTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/ReplTest.java
@@ -1,0 +1,127 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import static org.junit.Assert.fail;
+
+import static org.metaborg.spoofax.shell.client.console.TerminalUserInterfaceTest.C_D;
+import static org.metaborg.spoofax.shell.client.console.TerminalUserInterfaceTest.ENTER;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.RETURNS_MOCKS;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import org.junit.Test;
+import org.metaborg.spoofax.shell.client.IEditor;
+import org.metaborg.spoofax.shell.client.console.Repl;
+import org.metaborg.spoofax.shell.client.console.Repl.ExitCommand;
+import org.metaborg.spoofax.shell.commands.CommandNotFoundException;
+import org.metaborg.spoofax.shell.commands.ICommandInvoker;
+import org.mockito.Mockito;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+/**
+ * Tests the Repl by simulating user input.
+ */
+public class ReplTest {
+    private ByteArrayInputStream in;
+    private ByteArrayOutputStream out;
+    private Repl repl;
+    private Injector injector;
+
+    private void createInjector(Module... overrides) {
+        Module overridden = Modules.override(new ReplModule()).with(overrides);
+        injector = Guice.createInjector(overridden);
+    }
+
+    /**
+     * Create initial injector, later to be overwritten by {@link #createRepl(String, Module...)}.
+     *
+     * @param inputString
+     *            The simulated user input.
+     * @throws UnsupportedEncodingException
+     *             When UTF-8 is not supported.
+     */
+    public void setUp(String inputString) throws UnsupportedEncodingException {
+        in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
+        out = new ByteArrayOutputStream();
+
+        injector = Guice.createInjector(new ReplModule());
+    }
+
+    /**
+     * Setup and inject the {@link InputStream}s and {@link OutputStream}s.
+     *
+     * @param overrides
+     *            Module overrides w.r.t. ReplModule.
+     * @throws IOException
+     *             When an IO error occurs upon construction of the {@link ConsoleReader}.
+     */
+    public void createRepl(Module... overrides) throws IOException {
+        createInjector(overrides);
+        repl = injector.getInstance(Repl.class);
+    }
+
+    /**
+     * Test whether the Repl exits when Ctrl + D is pressed.
+     */
+    @Test
+    public void testCtrlDDoesExit() {
+        try {
+            setUp(String.valueOf(C_D));
+            ICommandInvoker mock = mock(ICommandInvoker.class, RETURNS_MOCKS);
+            createRepl(new UserInputSimulationModule(in, out), new MockModule(mock));
+            repl.run();
+            // Ensure that the command invoker is never called with any command.
+            verify(mock, never()).execute(anyString());
+        } catch (IOException | CommandNotFoundException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Tests the {@link ExitCommand}.
+     */
+    @Test
+    public void testExitCommand() {
+        try {
+            setUp(":exit" + ENTER + ENTER + ":exit" + ENTER + ENTER);
+            createInjector(new UserInputSimulationModule(in, out));
+            ICommandInvoker invokerMock = spy(injector.getInstance(ICommandInvoker.class));
+            IEditor editorMock = spy(injector.getInstance(IEditor.class));
+
+            // Create a Repl with the mock invoker and editor.
+            createRepl(new UserInputSimulationModule(in, out),
+                       new MockModule(invokerMock, editorMock));
+
+            // Hack: Create an ExitCommand manually, by giving a provider to the repl instance.
+            // Then stub the invoker so that it returns this exitCommand, not its own.
+            Repl.ExitCommand exitCommandMock = spy(new Repl.ExitCommand(() -> repl));
+            Mockito.when(invokerMock.commandFromName("exit")).thenReturn(exitCommandMock);
+
+            repl.run();
+
+            // Ensure that the command was given to the invoker just once.
+            verify(invokerMock, times(1)).execute(":exit");
+
+            // Ensure that exitCommand was executed once.
+            verify(exitCommandMock, times(1)).execute();
+
+            // Verify that the Editor was not asked for input after the exit command was executed.
+            verify(editorMock, times(1)).getInput();
+        } catch (IOException | CommandNotFoundException e) {
+            fail("Should not happen");
+        }
+    }
+}

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/ReplTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/ReplTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -46,7 +48,7 @@ public class ReplTest {
     }
 
     /**
-     * Create initial injector, later to be overwritten by {@link #createRepl(String, Module...)}.
+     * Create initial injector, can be overridden later on by {@link #createInjector(Module...)}.
      *
      * @param inputString
      *            The simulated user input.
@@ -65,10 +67,8 @@ public class ReplTest {
      *
      * @param overrides
      *            Module overrides w.r.t. ReplModule.
-     * @throws IOException
-     *             When an IO error occurs upon construction of the {@link ConsoleReader}.
      */
-    public void createRepl(Module... overrides) throws IOException {
+    public void createRepl(Module... overrides) {
         createInjector(overrides);
         repl = injector.getInstance(Repl.class);
     }

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -13,12 +13,9 @@ import java.io.OutputStream;
 import org.junit.Test;
 import org.metaborg.spoofax.shell.client.console.TerminalUserInterface;
 
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
-import com.google.inject.name.Names;
 
-import jline.TerminalSupport;
 import jline.console.ConsoleReader;
 
 /**
@@ -29,12 +26,12 @@ public class TerminalUserInterfaceTest {
     private static final String PROMPT = "<TEST>";
     private static final String CONT_PROMPT = ".TEST.";
     private static final char C_A = '\001';
-    private static final char C_D = '\004';
+    public static final char C_D = '\004';
     private static final char C_E = '\005';
     private static final char ESC = '\033';
     private static final String ARROW_UP = ESC + "[A";
     private static final String ARROW_DOWN = ESC + "[B";
-    private static final char ENTER = '\r';
+    public static final char ENTER = '\r';
     private static final String ASDF_QWERTY = /* >>> */ "asdf" + ENTER
     /* ... */ + ENTER
     /* >>> */ + "qwerty" + ENTER
@@ -54,17 +51,7 @@ public class TerminalUserInterfaceTest {
         in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
         out = new ByteArrayOutputStream();
 
-        ConsoleReader reader = new ConsoleReader(in, out, new TerminalSupport(true) {
-        });
-        Injector injector = Guice.createInjector(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(ConsoleReader.class).toInstance(reader);
-                bind(InputStream.class).annotatedWith(Names.named("in")).toInstance(in);
-                bind(OutputStream.class).annotatedWith(Names.named("out")).toInstance(out);
-                bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(out);
-            }
-        });
+        Injector injector = Guice.createInjector(new UserInputSimulationModule(in, out));
         ui = injector.getInstance(TerminalUserInterface.class);
         ui.setPrompt(PROMPT);
         ui.setContinuationPrompt(CONT_PROMPT);

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -47,7 +47,7 @@ public class TerminalUserInterfaceTest {
      *             When an IO error occurs upon construction of the {@link ConsoleReader}.
      */
     public void setUp(String inputString) throws IOException {
-        in = new ByteArrayInputStream(inputString.getBytes());
+        in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
         out = new ByteArrayOutputStream();
 
         ConsoleReader reader = new ConsoleReader(in, out, new TerminalSupport(true) {
@@ -93,7 +93,7 @@ public class TerminalUserInterfaceTest {
             /* ... */ + ENTER);
             assertEquals("asdf\nqwerty", ui.getInput());
             assertEquals(PROMPT + "asdf\n" + CONT_PROMPT + "qwerty\n" + CONT_PROMPT + '\n',
-                         out.toString());
+                         out.toString("UTF-8"));
         } catch (IOException e) {
             fail("Should not happen");
         }

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -1,0 +1,117 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.junit.Test;
+import org.metaborg.spoofax.shell.client.console.TerminalUserInterface;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.name.Names;
+
+import jline.TerminalSupport;
+import jline.console.ConsoleReader;
+
+/**
+ * Tests the {@link TerminalUserInterface} by simulating user input.
+ */
+public class TerminalUserInterfaceTest {
+    private TerminalUserInterface ui;
+    private static final String PROMPT = "<TEST>";
+    private static final String CONT_PROMPT = ".TEST.";
+    private static final char ESC = '\033';
+    private static final String ARROW_UP = ESC + "[A";
+    private static final String ARROW_DOWN = ESC + "[B";
+    private static final char ENTER = '\r';
+    private static final String ASDF_QWERTY = /* >>> */ "asdf" + ENTER
+    /* ... */ + ENTER
+    /* >>> */ + "qwerty" + ENTER
+    /* ... */ + ENTER;
+    private ByteArrayInputStream in;
+    private ByteArrayOutputStream out;
+
+    /**
+     * Setup and inject the {@link InputStream}s and {@link OutputStream}s.
+     *
+     * @param inputString
+     *            The simulated user input.
+     * @throws IOException
+     *             When an IO error occurs upon construction of the {@link ConsoleReader}.
+     */
+    public void setUp(String inputString) throws IOException {
+        in = new ByteArrayInputStream(inputString.getBytes());
+        out = new ByteArrayOutputStream();
+
+        ConsoleReader reader = new ConsoleReader(in, out, new TerminalSupport(true) {
+        });
+        Injector injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(ConsoleReader.class).toInstance(reader);
+                bind(InputStream.class).annotatedWith(Names.named("in")).toInstance(in);
+                bind(OutputStream.class).annotatedWith(Names.named("out")).toInstance(out);
+                bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(out);
+            }
+        });
+        ui = injector.getInstance(TerminalUserInterface.class);
+        ui.setPrompt(PROMPT);
+        ui.setContinuationPrompt(CONT_PROMPT);
+    }
+
+    /**
+     * Test whether an up-arrow causes the input to be the previously entered input.
+     */
+    @Test
+    public void testHistory_single() {
+        try {
+            setUp(ASDF_QWERTY/* >>> */ + ARROW_UP /* qwerty */ + ENTER + ENTER);
+            ui.getInput(); // asdf
+            ui.getInput(); // qwerty
+            assertEquals("qwerty", ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Test whether two up-arrows causes the input to be the input entered two times before.
+     */
+    @Test
+    public void testHistory_double() {
+        try {
+            setUp(ASDF_QWERTY/* >>> */ + ARROW_UP /* qwerty */ + ARROW_UP /* asdf */ + ENTER
+                  + ENTER);
+            ui.getInput(); // asdf
+            ui.getInput(); // qwerty
+            assertEquals("asdf", ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Test whether an up-arrow followed by a down-arrow causes the input to be the previously
+     * entered input.
+     */
+    @Test
+    public void testHistory_up_up_down() {
+        try {
+            setUp(ASDF_QWERTY/* >>> */ + ARROW_UP /* qwerty */ + ARROW_UP /* asdf */
+                  + ARROW_DOWN /* qwerty */ + ENTER + ENTER);
+            ui.getInput(); // asdf
+            ui.getInput(); // qwerty
+            assertEquals("qwerty", ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+}

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -1,6 +1,7 @@
 package org.metaborg.spoofax.shell.client.console;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
@@ -27,6 +28,7 @@ public class TerminalUserInterfaceTest {
     private TerminalUserInterface ui;
     private static final String PROMPT = "<TEST>";
     private static final String CONT_PROMPT = ".TEST.";
+    private static final char C_D = '\04';
     private static final char ESC = '\033';
     private static final String ARROW_UP = ESC + "[A";
     private static final String ARROW_DOWN = ESC + "[B";
@@ -64,6 +66,33 @@ public class TerminalUserInterfaceTest {
         ui = injector.getInstance(TerminalUserInterface.class);
         ui.setPrompt(PROMPT);
         ui.setContinuationPrompt(CONT_PROMPT);
+    }
+
+    /**
+     * Test whether entering CTRL + D returns null for input.
+     */
+    @Test
+    public void testCtrlD() {
+        try {
+            setUp(String.valueOf(C_D));
+            assertNull(ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Test whether entering CTRL + D returns null for input when entered on the second line.
+     */
+    @Test
+    public void testCtrlDEnteredOnSecondLine() {
+        try {
+            setUp(/* >>> */"asdf" + ENTER
+            /* ... */ + C_D);
+            assertNull(ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
     }
 
     /**

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -28,7 +28,9 @@ public class TerminalUserInterfaceTest {
     private TerminalUserInterface ui;
     private static final String PROMPT = "<TEST>";
     private static final String CONT_PROMPT = ".TEST.";
-    private static final char C_D = '\04';
+    private static final char C_A = '\001';
+    private static final char C_D = '\004';
+    private static final char C_E = '\005';
     private static final char ESC = '\033';
     private static final String ARROW_UP = ESC + "[A";
     private static final String ARROW_DOWN = ESC + "[B";
@@ -90,6 +92,21 @@ public class TerminalUserInterfaceTest {
             setUp(/* >>> */"asdf" + ENTER
             /* ... */ + C_D);
             assertNull(ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Test keyboard shortcuts (CTRL + A, CTRL + E).
+     */
+    @Test
+    public void testKeyboardShortcuts() {
+        try {
+            setUp(/* >>> */"asdf" + C_A + "qwerty" + C_E + "hjkl" + ENTER
+            /* ... */ + "sdf" + C_A + 'a' + ENTER
+            /* ... */ + ENTER);
+            assertEquals("qwertyasdfhjkl\nasdf", ui.getInput());
         } catch (IOException e) {
             fail("Should not happen");
         }

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -67,6 +67,39 @@ public class TerminalUserInterfaceTest {
     }
 
     /**
+     * Test whether interleaving lines with "ENTER", and then accepting the lines with double
+     * "ENTER", returns input that spans multiple lines.
+     */
+    @Test
+    public void testMultilineInput() {
+        try {
+            setUp(/* >>> */ "asdf" + ENTER
+            /* ... */ + "qwerty" + ENTER
+            /* ... */ + ENTER);
+            assertEquals("asdf\nqwerty", ui.getInput());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Test whether the continuation prompt is shown when entering multiline input.
+     */
+    @Test
+    public void testContinuationPromptShown() {
+        try {
+            setUp(/* >>> */ "asdf" + ENTER
+            /* ... */ + "qwerty" + ENTER
+            /* ... */ + ENTER);
+            assertEquals("asdf\nqwerty", ui.getInput());
+            assertEquals(PROMPT + "asdf\n" + CONT_PROMPT + "qwerty\n" + CONT_PROMPT + '\n',
+                         out.toString());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
      * Test whether an up-arrow causes the input to be the previously entered input.
      */
     @Test

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -12,6 +12,7 @@ import java.io.OutputStream;
 
 import org.junit.Test;
 import org.metaborg.spoofax.shell.client.console.TerminalUserInterface;
+import org.metaborg.spoofax.shell.commands.StyledText;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -53,8 +54,8 @@ public class TerminalUserInterfaceTest {
 
         Injector injector = Guice.createInjector(new UserInputSimulationModule(in, out));
         ui = injector.getInstance(TerminalUserInterface.class);
-        ui.setPrompt(PROMPT);
-        ui.setContinuationPrompt(CONT_PROMPT);
+        ui.setPrompt(new StyledText(PROMPT));
+        ui.setContinuationPrompt(new StyledText(CONT_PROMPT));
     }
 
     /**

--- a/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/UserInputSimulationModule.java
+++ b/shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/UserInputSimulationModule.java
@@ -1,0 +1,48 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+
+import jline.TerminalSupport;
+import jline.console.ConsoleReader;
+
+/**
+ * Binds a ConsoleReader so that it can be used to simulate user input.
+ */
+public class UserInputSimulationModule extends AbstractModule {
+
+    private InputStream in;
+    private OutputStream out;
+    private ConsoleReader reader;
+
+    /**
+     * @param in
+     *            The {@link InputStream}, which can contain simulated user input such as
+     *            arrow-keys, return key, Ctrl+A ... Ctrl+Z, and other control codes.
+     * @param out
+     *            The {@link OutputStream}, which includes the prompts and verified user input.
+     * @throws IOException
+     *             When an IO error occurs upon construction of the {@link ConsoleReader}.
+     */
+    public UserInputSimulationModule(InputStream in, OutputStream out) throws IOException {
+        // Set custom terminal to be "supported", so that control codes are captured.
+        reader = new ConsoleReader(in, out, new TerminalSupport(true) {
+        });
+
+        this.in = in;
+        this.out = out;
+    }
+
+    @Override
+    protected void configure() {
+        bind(ConsoleReader.class).toInstance(reader);
+        bind(InputStream.class).annotatedWith(Names.named("in")).toInstance(in);
+        bind(OutputStream.class).annotatedWith(Names.named("out")).toInstance(out);
+        bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(out);
+    }
+
+}


### PR DESCRIPTION
The ConsoleReader is injected using an `@Provides` method in the ReplModule.

In the test, it is injected with a special ConsoleReader in which I explicitly set "terminal support", so that it interprets control codes like `UP`, `DOWN` and `ENTER`. This way I can test as if I type in a terminal.

The "terminal support" is also used to test the Repl. A bug has been found and is resolved too.
