### PR TITLE
[RDY] Implement persistent history.

### DIFF
--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ConsoleRepl.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ConsoleRepl.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.io.IOException;
 
 import org.metaborg.spoofax.shell.client.IDisplay;
+import org.metaborg.spoofax.shell.client.IEditor;
 import org.metaborg.spoofax.shell.client.Repl;
 import org.metaborg.spoofax.shell.core.StyledText;
 
@@ -33,9 +34,17 @@ public final class ConsoleRepl {
      *             When an IO error occurs during execution.
      */
     public static void main(String[] args) throws IOException {
+        IEditor editor = injector.getInstance(IEditor.class);
+        IDisplay display = injector.getInstance(IDisplay.class);
+        Repl repl = injector.getInstance(Repl.class);
         StyledText message = new StyledText(Color.BLUE, "Welcome to the ")
             .append(Color.GREEN, "Spoofax").append(Color.BLUE, " REPL");
-        injector.getInstance(IDisplay.class).displayResult(message);
-        injector.getInstance(Repl.class).run();
+
+        editor.history().loadFromDisk();
+        display.displayResult(message);
+
+        repl.run();
+
+        editor.history().persistToDisk();
     }
 }

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ConsoleReplModule.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ConsoleReplModule.java
@@ -20,6 +20,8 @@ import com.google.inject.name.Names;
 public class ConsoleReplModule extends ReplModule {
 
     private void configureUserInterface() {
+        bind(JLine2InputHistory.class).to(JLine2PersistentInputHistory.class);
+
         bind(TerminalUserInterface.class).in(Singleton.class);
         bind(IEditor.class).to(TerminalUserInterface.class);
         bind(IDisplay.class).to(TerminalUserInterface.class);
@@ -29,7 +31,7 @@ public class ConsoleReplModule extends ReplModule {
         bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(System.err);
 
         bindConstant().annotatedWith(Names.named("historyPath"))
-            .to(System.getProperty("user.dir") + "/.spoofax-shell_history");
+            .to(System.getProperty("user.home") + "/.spoofax_history");
     }
 
     @Override
@@ -49,7 +51,7 @@ public class ConsoleReplModule extends ReplModule {
      *            The {@link InputStream}.
      * @param out
      *            The {@link OutputStream}.
-     * @return a {@link ConsoleReader} with the given streams.
+     * @return a {@link jline.console.ConsoleReader} with the given streams.
      * @throws IOException
      *             When an IO error occurs upon construction.
      */

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ConsoleReplModule.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/ConsoleReplModule.java
@@ -14,8 +14,6 @@ import com.google.inject.Singleton;
 import com.google.inject.name.Named;
 import com.google.inject.name.Names;
 
-import jline.console.ConsoleReader;
-
 /**
  * Bindings for the console repl.
  */
@@ -29,6 +27,9 @@ public class ConsoleReplModule extends ReplModule {
         bind(InputStream.class).annotatedWith(Names.named("in")).toInstance(System.in);
         bind(OutputStream.class).annotatedWith(Names.named("out")).toInstance(System.out);
         bind(OutputStream.class).annotatedWith(Names.named("err")).toInstance(System.err);
+
+        bindConstant().annotatedWith(Names.named("historyPath"))
+            .to(System.getProperty("user.dir") + "/.spoofax-shell_history");
     }
 
     @Override
@@ -54,9 +55,9 @@ public class ConsoleReplModule extends ReplModule {
      */
     @Provides
     @Singleton
-    protected ConsoleReader provideConsoleReader(@Named("in") InputStream in,
-                                                 @Named("out") OutputStream out)
-                                                     throws IOException {
-        return new ConsoleReader(in, out);
+    protected jline.console.ConsoleReader provideConsoleReader(@Named("in") InputStream in,
+                                                               @Named("out") OutputStream out)
+                                                                   throws IOException {
+        return new jline.console.ConsoleReader(in, out);
     }
 }

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistory.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistory.java
@@ -13,7 +13,7 @@ import com.google.inject.Inject;
  */
 public class JLine2InputHistory implements IInputHistory {
     protected jline.console.ConsoleReader reader;
-    private jline.console.history.MemoryHistory delegateHist;
+    private final jline.console.history.MemoryHistory delegateHist;
 
     /**
      * @param reader
@@ -23,8 +23,8 @@ public class JLine2InputHistory implements IInputHistory {
      *            The jline2 history implementation that will be delegated to.
      */
     @Inject
-    JLine2InputHistory(jline.console.ConsoleReader reader,
-                       jline.console.history.MemoryHistory delegateHist) {
+    JLine2InputHistory(final jline.console.ConsoleReader reader,
+                       final jline.console.history.MemoryHistory delegateHist) {
         this.reader = reader;
         this.delegateHist = delegateHist;
         reader.setHistory(delegateHist);

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistory.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistory.java
@@ -1,0 +1,68 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.metaborg.spoofax.shell.client.IInputHistory;
+
+import com.google.inject.Inject;
+
+/**
+ * An adapter for JLine2's History implementation.
+ */
+public class JLine2InputHistory implements IInputHistory {
+    protected jline.console.ConsoleReader reader;
+    private jline.console.history.MemoryHistory delegateHist;
+
+    /**
+     * @param reader
+     *            The {@link jline.console.ConsoleReader ConsoleReader} for setting the history
+     *            being used.
+     * @param delegateHist
+     *            The jline2 history implementation that will be delegated to.
+     */
+    @Inject
+    JLine2InputHistory(jline.console.ConsoleReader reader,
+                       jline.console.history.MemoryHistory delegateHist) {
+        this.reader = reader;
+        this.delegateHist = delegateHist;
+        reader.setHistory(delegateHist);
+    }
+
+    /**
+     * @return The delegate that is currently active. When the
+     *         {@link jline.console.history.FileHistory FileHistory} delegate has not been loaded
+     *         from disk, the {@link jline.console.history.MemoryHistory MemoryHistory} delegate is
+     *         used instead.
+     */
+    protected jline.console.history.History delegate() {
+        return delegateHist;
+    }
+
+    @Override
+    public String get(int index) {
+        return delegate().get(index).toString();
+    }
+
+    @Override
+    public void append(String newEntry) {
+        delegate().add(newEntry);
+    }
+
+    @Override
+    public int size() {
+        return delegate().size();
+    }
+
+    @Override
+    public List<String> entries(int from, int to) {
+        // @formatter:off
+        return StreamSupport.stream(delegate().spliterator(), false)
+            .skip(from)
+            .limit(to - from)
+            .map(entry -> entry.value().toString())
+            .collect(Collectors.toList());
+        // @formatter:on
+    }
+}

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistory.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistory.java
@@ -61,11 +61,10 @@ public class JLine2PersistentInputHistory extends JLine2InputHistory {
         jline.console.history.FileHistory newDelegate =
             new jline.console.history.FileHistory(histFile);
 
-        // Have to clear so that I can add all the old entries in front again...
-        // newDelegate.clear();
-        // delegate().forEach(e -> newDelegate.add(e.value().toString()));
-        // newDelegate.load(histFile);
+        // Add the in-memory entries too.
+        delegate().forEach(e -> newDelegate.add(e.value().toString()));
 
+        // Set the new delegate to be used.
         reader.setHistory(newDelegate);
         delegateFileHist = Optional.of(newDelegate);
     }

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistory.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistory.java
@@ -1,0 +1,80 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+
+/**
+ * An extension to the adapter for JLine2's History implementation. This adapter implementation
+ * maintains two versions of JLine2's History classes: one that is initially used in-memory, and
+ * another persistent History implementation which is used when {@link #loadFromDisk()} has been
+ * called.
+ *
+ * Thus initially the in-memory version is used. When the input history has been loaded from disk,
+ * the adapter switches to using a persistent history version which can be used to save back to disk
+ * again using {@link #persistToDisk()}.
+ */
+public class JLine2PersistentInputHistory extends JLine2InputHistory {
+    private String filePath;
+    private Optional<jline.console.history.FileHistory> delegateFileHist;
+
+    /**
+     * @param filePath
+     *            The file path from which the history is loaded and to which the history is
+     *            persisted.
+     * @param reader
+     *            The {@link jline.console.ConsoleReader ConsoleReader} for setting the correct
+     *            delegate.
+     * @param delegateHist
+     *            The jline2 history implementation that will be delegated to as long as history has
+     *            not been loaded from disk.
+     */
+    @Inject
+    JLine2PersistentInputHistory(@Named("historyPath") String filePath,
+                                 jline.console.ConsoleReader reader,
+                                 jline.console.history.MemoryHistory delegateHist) {
+        super(reader, delegateHist);
+        this.filePath = filePath;
+        reader.setHistory(delegateHist);
+        delegateFileHist = Optional.empty();
+    }
+
+    /**
+     * @return The delegate that is currently active. When the
+     *         {@link jline.console.history.FileHistory FileHistory} delegate has not been loaded
+     *         from disk, the {@link jline.console.history.MemoryHistory MemoryHistory} delegate is
+     *         used instead.
+     */
+    protected jline.console.history.History delegate() {
+        // orElse does not work on a subtype, but it does if you put flatMap in between.
+        return delegateFileHist
+            .flatMap((jline.console.history.History fileHist) -> Optional.of(fileHist))
+            .orElse(super.delegate());
+    }
+
+    @Override
+    public void loadFromDisk() throws IOException {
+        File histFile = new File(filePath);
+        jline.console.history.FileHistory newDelegate =
+            new jline.console.history.FileHistory(histFile);
+
+        // Have to clear so that I can add all the old entries in front again...
+        // newDelegate.clear();
+        // delegate().forEach(e -> newDelegate.add(e.value().toString()));
+        // newDelegate.load(histFile);
+
+        reader.setHistory(newDelegate);
+        delegateFileHist = Optional.of(newDelegate);
+    }
+
+    @Override
+    public void persistToDisk() throws IOException {
+        // Cannot use ifPresent, because I have to catch an IOException inside the lambda.
+        if (delegateFileHist.isPresent()) {
+            delegateFileHist.get().flush();
+        }
+    }
+}

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistory.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistory.java
@@ -18,7 +18,7 @@ import com.google.inject.name.Named;
  * again using {@link #persistToDisk()}.
  */
 public class JLine2PersistentInputHistory extends JLine2InputHistory {
-    private String filePath;
+    private final String filePath;
     private Optional<jline.console.history.FileHistory> delegateFileHist;
 
     /**
@@ -57,7 +57,7 @@ public class JLine2PersistentInputHistory extends JLine2InputHistory {
 
     @Override
     public void loadFromDisk() throws IOException {
-        File histFile = new File(filePath);
+        final File histFile = new File(filePath);
         jline.console.history.FileHistory newDelegate =
             new jline.console.history.FileHistory(histFile);
 

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterface.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterface.java
@@ -3,6 +3,7 @@ package org.metaborg.spoofax.shell.client.console;
 import static org.metaborg.spoofax.shell.client.console.AnsiColors.findClosest;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -25,6 +26,8 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 import jline.console.ConsoleReader;
+import jline.console.history.FileHistory;
+import jline.console.history.History;
 
 /**
  * A terminal UI which is both an {@link IEditor} and an {@link IDisplay}.
@@ -44,16 +47,22 @@ public class TerminalUserInterface implements IEditor, IDisplay {
      *            The {@link PrintStream} to write results to.
      * @param err
      *            The {@link PrintStream} to write errors to.
+     * @param path
+     *            The file path to write the history to.
      * @throws IOException
      *             when an IO error occurs.
      */
     @Inject
     public TerminalUserInterface(ConsoleReader reader, @Named("out") OutputStream out,
-                                 @Named("err") OutputStream err) throws IOException {
+                                 @Named("err") OutputStream err, @Named("historyPath") String path)
+                                     throws IOException {
         this.reader = reader;
         reader.setExpandEvents(false);
         reader.setHandleUserInterrupt(true);
         reader.setBellEnabled(true);
+        File file = new File(path);
+        History hist = new FileHistory(file);
+        reader.setHistory(hist);
         this.out =
             new PrintWriter(new BufferedWriter(new OutputStreamWriter(out,
                                                                       Charset.forName("UTF-8"))));

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistoryTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistoryTest.java
@@ -1,0 +1,199 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.metaborg.spoofax.shell.client.console.TerminalUserInterfaceTest.ENTER;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+import org.metaborg.spoofax.shell.core.StyledText;
+import org.mockito.Mockito;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.util.Modules;
+
+/**
+ * Tests the JLine2 history adapter. It tests the interplay between our interface and theirs: first
+ * history entries are added by user-simulation in {@link #setUp(String)}, and then the test
+ * operates on it via our interface, to see if it correctly implements an adapter towards the
+ * outside.
+ */
+public class JLine2InputHistoryTest {
+    protected JLine2InputHistory hist;
+    protected jline.console.history.MemoryHistory theDelegate;
+    protected ByteArrayInputStream in;
+    protected ByteArrayOutputStream out;
+
+    protected static final int HIST_GET_OUT_OF_BOUND_LEFT = -1;
+    protected static final int HIST_GET_OUT_OF_BOUND_RIGHT = 2;
+
+    protected static final int HIST_SIZE_BEFORE_APPEND = 2;
+    protected static final int HIST_SIZE_AFTER_APPEND = 3;
+
+    protected static final int HIST_ENTRIES_FROM_INDEX = 1;
+    protected static final int HIST_ENTRIES_TO_INDEX = 3;
+
+    /**
+     * Setup and inject the {@link InputStream}s and {@link OutputStream}s.
+     *
+     * @param inputString
+     *            The simulated user input.
+     * @throws IOException
+     *             When an IO error occurs upon construction of the {@link ConsoleReader}.
+     */
+    public void setUp(String inputString) throws IOException {
+        in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
+        out = new ByteArrayOutputStream();
+        theDelegate = Mockito.spy(new jline.console.history.MemoryHistory());
+        Injector injector = Guice.createInjector(Modules
+            .override(new UserInputSimulationModule(in, out)).with(moduleOverride()));
+        hist = injector.getInstance(JLine2InputHistory.class);
+        // We use this just to process the input and put stuff in the history.
+        TerminalUserInterface ui = injector.getInstance(TerminalUserInterface.class);
+        ui.setPrompt(new StyledText(TerminalUserInterfaceTest.PROMPT));
+        ui.setContinuationPrompt(new StyledText(TerminalUserInterfaceTest.CONT_PROMPT));
+        ui.getInput();
+    }
+
+    /**
+     * @return The bindings that override or extend those of the {@link UserInputSimulationModule}.
+     */
+    protected Module moduleOverride() {
+        return b -> {
+            // Override ConsoleReplModule to use JLine2InputHistory, instead of the persistent
+            // version.
+            b.bind(JLine2InputHistory.class);
+            // Bind jline's MemoryHistory so that we can test the adapter.
+            b.bind(jline.console.history.MemoryHistory.class).toInstance(theDelegate);
+        };
+    }
+
+    private static void assertOutOfBoundsException(Supplier<?> fun) {
+        try {
+            fun.get();
+            fail("IndexOutOfBoundsException expected, but did not get thrown");
+        } catch (IndexOutOfBoundsException e) {
+        }
+    }
+
+    /**
+     * Tests whether the {@link JLine2InputHistory#get(int)} method correctly returns entries
+     * entered through simulated input.
+     */
+    @Test
+    public final void testGet() {
+        try {
+            setUp("asdf" + ENTER + "fdsa" + ENTER);
+            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+            assertEquals("asdf", hist.get(0));
+            assertEquals("fdsa", hist.get(1));
+            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_LEFT));
+            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT));
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Tests whether the {@link JLine2InputHistory#append(String)} method correctly adds a new entry
+     * via our own interface. First tests on user-simulated input for two entries, and tests whether
+     * the entry at index 2 is out of bounds. Then a new entry is appended via our adapter, and the
+     * entry that was previously out of bound should now return the newly added entry.
+     */
+    @Test
+    public final void testAppend() {
+        try {
+            setUp("asdf" + ENTER + "fdsa" + ENTER);
+            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+            assertEquals("asdf", hist.get(0));
+            assertEquals("fdsa", hist.get(1));
+            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_LEFT));
+            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT));
+            hist.append("qwerty");
+            Mockito.verify(theDelegate).add("qwerty");
+
+            // This is the same as hist.get(HIST_GET_OUT_OF_BOUND_RIGHT)
+            assertEquals("qwerty", hist.get(2));
+            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT + 1));
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Tests whether the {@link JLine2InputHistory#getMostRecent()} method correctly returns the
+     * most recent entry entered through simulated input, and then an entry appended via our
+     * interface.
+     */
+    @Test
+    public final void testGetMostRecent() {
+        try {
+            setUp("asdf" + ENTER + "fdsa" + ENTER);
+            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+            assertEquals("fdsa", hist.getMostRecent());
+            hist.append("qwerty");
+            assertEquals(HIST_SIZE_AFTER_APPEND, hist.size());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Tests whether the size is reported correctly after input-simulation, and whether it is
+     * reported correctly after appending a new entry via our own adapter interface.
+     */
+    @Test
+    public final void testSize() {
+        try {
+            setUp("asdf" + ENTER + "fdsa" + ENTER);
+            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+            assertEquals(HIST_SIZE_BEFORE_APPEND, hist.size());
+            hist.append("qwerty");
+            assertEquals(HIST_SIZE_AFTER_APPEND, hist.size());
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Tests the following methods:
+     * <li>{@link JLine2InputHistory#allEntries()}</li>
+     * <li>{@link JLine2InputHistory#entries(int)}</li>
+     * <li>{@link JLine2InputHistory#entries(int, int)}</li>.
+     */
+    @Test
+    public final void testEntries() {
+        try {
+            setUp("asdf" + ENTER + "fdsa" + ENTER + "qwerty" + ENTER + "uiop" + ENTER);
+            assertThat(hist.allEntries(), hasItems("asdf", "fdsa", "qwerty", "uiop"));
+            // From index is inclusive.
+            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX), hasItems("fdsa", "qwerty", "uiop"));
+            // To index is exclusive.
+            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX),
+                       hasItems("fdsa", "qwerty"));
+            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX - 1),
+                       hasItems("fdsa"));
+
+            // Add a new entry from our own interface.
+            hist.append("hjkl");
+            assertThat(hist.allEntries(), hasItems("asdf", "fdsa", "qwerty", "uiop", "hjkl"));
+            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX),
+                       hasItems("fdsa", "qwerty", "uiop", "hjkl"));
+            // This one should not have changed.
+            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX),
+                       hasItems("fdsa", "qwerty"));
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+}

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistoryTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2InputHistoryTest.java
@@ -49,7 +49,8 @@ public class JLine2InputHistoryTest {
      * @param inputString
      *            The simulated user input.
      * @throws IOException
-     *             When an IO error occurs upon construction of the {@link ConsoleReader}.
+     *             When an IO error occurs upon construction of the
+     *             {@link jline.console.ConsoleReader ConsoleReader}.
      */
     public void setUp(String inputString) throws IOException {
         in = new ByteArrayInputStream(inputString.getBytes("UTF-8"));
@@ -166,10 +167,8 @@ public class JLine2InputHistoryTest {
     }
 
     /**
-     * Tests the following methods:
-     * <li>{@link JLine2InputHistory#allEntries()}</li>
-     * <li>{@link JLine2InputHistory#entries(int)}</li>
-     * <li>{@link JLine2InputHistory#entries(int, int)}</li>.
+     * Tests the following methods: {@link JLine2InputHistory#allEntries()} ,
+     * {@link JLine2InputHistory#entries(int)} , {@link JLine2InputHistory#entries(int, int)}.
      */
     @Test
     public final void testEntries() {

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistoryTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistoryTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
-import static org.metaborg.util.test.Assert2.assertEmpty;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
@@ -80,16 +79,17 @@ public class JLine2PersistentInputHistoryTest extends JLine2InputHistoryTest {
         try {
             assertThat(hist.allEntries(), hasItems("asdf", "fdsa"));
 
-            // Now load entries from disk. The file is empty, so allEntries should be empty.
+            // Now load entries from disk. The file is empty, so allEntries should still have all
+            // in-memory contents as before.
             systemUnderTest().loadFromDisk();
-            assertEmpty(hist.allEntries());
+            assertThat(hist.allEntries(), hasItems("asdf", "fdsa"));
 
             hist.append("qwerty");
             hist.append("hjkl");
 
             // Persist to disk, check the file contents.
             systemUnderTest().persistToDisk();
-            assertEquals("qwerty\nhjkl\n", Files.toString(tempHistory, Charsets.UTF_8));
+            assertEquals("asdf\nfdsa\nqwerty\nhjkl\n", Files.toString(tempHistory, Charsets.UTF_8));
 
             // Load it back and check that the entries are there.
             systemUnderTest().loadFromDisk();

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistoryTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/JLine2PersistentInputHistoryTest.java
@@ -1,0 +1,102 @@
+package org.metaborg.spoofax.shell.client.console;
+
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.metaborg.spoofax.shell.client.console.TerminalUserInterfaceTest.ENTER;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.metaborg.util.test.Assert2.assertEmpty;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+
+import jline.console.history.FileHistory;
+import jline.console.history.MemoryHistory;
+
+/**
+ * Tests the loading and saving of the history from and to the disk.
+ */
+public class JLine2PersistentInputHistoryTest extends JLine2InputHistoryTest {
+    private File tempHistory;
+
+    /**
+     * Create a temporary file.
+     *
+     * @throws IOException
+     *             When an IO error occurs while creating the file.
+     */
+    @Before
+    public void setUp() throws IOException {
+        tempHistory = File.createTempFile("test_history", ".tmp");
+        setUp("asdf" + ENTER + "fdsa" + ENTER + ENTER);
+    }
+
+    @Override
+    protected Module moduleOverride() {
+        return b -> {
+            // Bind the persistent history adapter.
+            b.bind(JLine2InputHistory.class).to(JLine2PersistentInputHistory.class);
+            // Bind jline's MemoryHistory so that we can test the adapter.
+            b.bind(jline.console.history.MemoryHistory.class).toInstance(theDelegate);
+            // Bind the temp file path.
+            b.bindConstant().annotatedWith(Names.named("historyPath")).to(tempHistory.getPath());
+        };
+    }
+
+    private JLine2PersistentInputHistory systemUnderTest() {
+        // This cast is safe as the JLine2InputHistory class was bound to the persistent version.
+        return (JLine2PersistentInputHistory) hist;
+    }
+
+    /**
+     * Tests the switch of the delegate before and after loading.
+     */
+    @Test
+    public void testDelegateSwitch() {
+        try {
+            assertEquals(theDelegate, systemUnderTest().delegate());
+            assertTrue(systemUnderTest().delegate() instanceof MemoryHistory);
+            systemUnderTest().loadFromDisk();
+            assertTrue(systemUnderTest().delegate() instanceof FileHistory);
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+    /**
+     * Tests persistence through creating a temporary file.
+     */
+    @Test
+    public void testPersistentHistory() {
+        try {
+            assertThat(hist.allEntries(), hasItems("asdf", "fdsa"));
+
+            // Now load entries from disk. The file is empty, so allEntries should be empty.
+            systemUnderTest().loadFromDisk();
+            assertEmpty(hist.allEntries());
+
+            hist.append("qwerty");
+            hist.append("hjkl");
+
+            // Persist to disk, check the file contents.
+            systemUnderTest().persistToDisk();
+            assertEquals("qwerty\nhjkl\n", Files.toString(tempHistory, Charsets.UTF_8));
+
+            // Load it back and check that the entries are there.
+            systemUnderTest().loadFromDisk();
+            assertThat(hist.allEntries(), hasItems("qwerty", "hjkl"));
+        } catch (IOException e) {
+            fail("Should not happen");
+        }
+    }
+
+}

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/TerminalUserInterfaceTest.java
@@ -24,8 +24,8 @@ import jline.console.ConsoleReader;
  */
 public class TerminalUserInterfaceTest {
     private TerminalUserInterface ui;
-    private static final String PROMPT = "<TEST>";
-    private static final String CONT_PROMPT = ".TEST.";
+    public static final String PROMPT = "<TEST>";
+    public static final String CONT_PROMPT = ".TEST.";
     private static final char C_A = '\001';
     public static final char C_D = '\004';
     private static final char C_E = '\005';
@@ -180,5 +180,4 @@ public class TerminalUserInterfaceTest {
             fail("Should not happen");
         }
     }
-
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IEditor.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IEditor.java
@@ -1,7 +1,6 @@
 package org.metaborg.spoofax.shell.client;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.metaborg.core.completion.ICompletionService;
 import org.metaborg.spoofax.core.unit.ISpoofaxParseUnit;
@@ -31,11 +30,9 @@ public interface IEditor {
     void setSpoofaxCompletion(ICompletionService<ISpoofaxParseUnit> completionService);
 
     /**
-     * TODO: Consider replacing a {@link List} of {@link String}s with a History type?
-     *
-     * @return the history of evaluated expressions, from recent to old.
+     * @return The history of evaluated expressions, oldest entries first.
      */
-    List<String> history();
+    IInputHistory history();
 
     /**
      * Set the prompt to display.

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IInputHistory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IInputHistory.java
@@ -1,0 +1,96 @@
+package org.metaborg.spoofax.shell.client;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * This interface represents the input history of a REPL session.
+ */
+public interface IInputHistory {
+
+    /**
+     * Append a new entry to the end of the input history.
+     *
+     * @param newEntry
+     *            The new entry to append.
+     */
+    void append(String newEntry);
+
+    /**
+     * Get the most recent input history entry. Default implementation is equal to {@link #get(int)
+     * get({@link #size()} - 1)}.
+     *
+     * @return The most recent history entry.
+     */
+    default String getMostRecent() {
+        return get(size() - 1);
+    }
+
+    /**
+     * Get a single history entry. Default implementation is equal to {@link #entries(int, int)
+     * entries(index, index + 1)}.{@link List#get(int) get(0)}.
+     *
+     * @param index
+     *            The index of the history entry.
+     * @return The history entry at the given index.
+     */
+    default String get(int index) {
+        return entries(index, index + 1).get(0);
+    }
+
+    /**
+     * @return The amount of history entries currently stored.
+     */
+    int size();
+
+    /**
+     * Same as {@link #entries(int) entries(0)}.
+     *
+     * @return All entries, oldest first.
+     */
+    default List<String> allEntries() {
+        return entries(0);
+    }
+
+    /**
+     * Same as {@link #entries(int, int) entries(from, #size())}.
+     *
+     * @param from
+     *            The index from which to return the history, inclusive.
+     * @return The history entries from the specified index, oldest first.
+     */
+    default List<String> entries(int from) {
+        return entries(from, size());
+    }
+
+    /**
+     * Return the entries in the specified range.
+     *
+     * @param from
+     *            The index from which to return the history, inclusive.
+     * @param to
+     *            The index to which to return the history, exclusive.
+     * @return The entries in the specified range, oldest first.
+     */
+    List<String> entries(int from, int to);
+
+    /**
+     * Optionally supported operation. When implemented, the input history should be read from a
+     * file.
+     *
+     * @throws IOException
+     *             When an IO error occurs while reading the input history from the file system.
+     */
+    default void loadFromDisk() throws IOException {
+    }
+
+    /**
+     * Optionally supported operation. When implemented, the input history should be written to a
+     * file.
+     *
+     * @throws IOException
+     *             When an IO error occurs while writing the input history to disk.
+     */
+    default void persistToDisk() throws IOException {
+    }
+}


### PR DESCRIPTION
I added an `IInputHistory` interface, so that we have an interface to talk to with other parts of our repl. I then created an adapter for JLine2's history implementation.
