### PR TITLE
[RDY] Add input history to Eclipse

### DIFF
--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/history/JLine2InputHistory.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/history/JLine2InputHistory.java
@@ -65,4 +65,21 @@ public class JLine2InputHistory implements IInputHistory {
             .collect(Collectors.toList());
         // @formatter:on
     }
+
+    @Override
+    public String getPrevious() {
+        delegate().previous();
+        return delegate().current().toString();
+    }
+
+    @Override
+    public String getNext() {
+        delegate().next();
+        return delegate().current().toString();
+    }
+
+    @Override
+    public void reset() {
+        delegate().moveToEnd();
+    }
 }

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/impl/history/JLine2InputHistoryTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/impl/history/JLine2InputHistoryTest.java
@@ -93,19 +93,18 @@ public class JLine2InputHistoryTest {
     /**
      * Tests whether the {@link JLine2InputHistory#get(int)} method correctly returns entries
      * entered through simulated input.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testGet() {
-        try {
-            setUp("asdf" + ENTER + "fdsa" + ENTER);
-            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
-            assertEquals("asdf", hist.get(0));
-            assertEquals("fdsa", hist.get(1));
-            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_LEFT));
-            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT));
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+    public void testGet() throws IOException {
+        setUp("asdf" + ENTER + "fdsa" + ENTER);
+        Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+        assertEquals("asdf", hist.get(0));
+        assertEquals("fdsa", hist.get(1));
+        assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_LEFT));
+        assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT));
     }
 
     /**
@@ -113,91 +112,118 @@ public class JLine2InputHistoryTest {
      * via our own interface. First tests on user-simulated input for two entries, and tests whether
      * the entry at index 2 is out of bounds. Then a new entry is appended via our adapter, and the
      * entry that was previously out of bound should now return the newly added entry.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testAppend() {
-        try {
-            setUp("asdf" + ENTER + "fdsa" + ENTER);
-            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
-            assertEquals("asdf", hist.get(0));
-            assertEquals("fdsa", hist.get(1));
-            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_LEFT));
-            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT));
-            hist.append("qwerty");
-            Mockito.verify(theDelegate).add("qwerty");
+    public void testAppend() throws IOException {
+        setUp("asdf" + ENTER + "fdsa" + ENTER);
+        Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+        assertEquals("asdf", hist.get(0));
+        assertEquals("fdsa", hist.get(1));
+        assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_LEFT));
+        assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT));
+        hist.append("qwerty");
+        Mockito.verify(theDelegate).add("qwerty");
 
-            // This is the same as hist.get(HIST_GET_OUT_OF_BOUND_RIGHT)
-            assertEquals("qwerty", hist.get(2));
-            assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT + 1));
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+        // This is the same as hist.get(HIST_GET_OUT_OF_BOUND_RIGHT)
+        assertEquals("qwerty", hist.get(2));
+        assertOutOfBoundsException(() -> hist.get(HIST_GET_OUT_OF_BOUND_RIGHT + 1));
     }
 
     /**
      * Tests whether the {@link JLine2InputHistory#getMostRecent()} method correctly returns the
      * most recent entry entered through simulated input, and then an entry appended via our
      * interface.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testGetMostRecent() {
-        try {
-            setUp("asdf" + ENTER + "fdsa" + ENTER);
-            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
-            assertEquals("fdsa", hist.getMostRecent());
-            hist.append("qwerty");
-            assertEquals(HIST_SIZE_AFTER_APPEND, hist.size());
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+    public void testGetMostRecent() throws IOException {
+        setUp("asdf" + ENTER + "fdsa" + ENTER);
+        Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+        assertEquals("fdsa", hist.getMostRecent());
+        hist.append("qwerty");
+        assertEquals(HIST_SIZE_AFTER_APPEND, hist.size());
     }
 
     /**
      * Tests whether the size is reported correctly after input-simulation, and whether it is
      * reported correctly after appending a new entry via our own adapter interface.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testSize() {
-        try {
-            setUp("asdf" + ENTER + "fdsa" + ENTER);
-            Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
-            assertEquals(HIST_SIZE_BEFORE_APPEND, hist.size());
-            hist.append("qwerty");
-            assertEquals(HIST_SIZE_AFTER_APPEND, hist.size());
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+    public void testSize() throws IOException {
+        setUp("asdf" + ENTER + "fdsa" + ENTER);
+        Mockito.verify(theDelegate, Mockito.times(2)).add(Mockito.anyString());
+        assertEquals(HIST_SIZE_BEFORE_APPEND, hist.size());
+        hist.append("qwerty");
+        assertEquals(HIST_SIZE_AFTER_APPEND, hist.size());
     }
 
     /**
      * Tests the following methods: {@link JLine2InputHistory#allEntries()} ,
      * {@link JLine2InputHistory#entries(int)}, {@link JLine2InputHistory#entries(int, int)}.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testEntries() {
-        try {
-            setUp("asdf" + ENTER + "fdsa" + ENTER + "qwerty" + ENTER + "uiop" + ENTER);
-            assertThat(hist.allEntries(), CoreMatchers.hasItems("asdf", "fdsa", "qwerty", "uiop"));
-            // From index is inclusive.
-            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX),
-                       CoreMatchers.hasItems("fdsa", "qwerty", "uiop"));
-            // To index is exclusive.
-            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX),
-                       CoreMatchers.hasItems("fdsa", "qwerty"));
-            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX - 1),
-                       CoreMatchers.hasItems("fdsa"));
+    public void testEntries() throws IOException {
+        setUp("asdf" + ENTER + "fdsa" + ENTER + "qwerty" + ENTER + "uiop" + ENTER);
+        assertThat(hist.allEntries(), CoreMatchers.hasItems("asdf", "fdsa", "qwerty", "uiop"));
+        // From index is inclusive.
+        assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX),
+                   CoreMatchers.hasItems("fdsa", "qwerty", "uiop"));
+        // To index is exclusive.
+        assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX),
+                   CoreMatchers.hasItems("fdsa", "qwerty"));
+        assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX - 1),
+                   CoreMatchers.hasItems("fdsa"));
 
-            // Add a new entry from our own interface.
-            hist.append("hjkl");
-            assertThat(hist.allEntries(),
-                       CoreMatchers.hasItems("asdf", "fdsa", "qwerty", "uiop", "hjkl"));
-            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX),
-                       CoreMatchers.hasItems("fdsa", "qwerty", "uiop", "hjkl"));
-            // This one should not have changed.
-            assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX),
-                       CoreMatchers.hasItems("fdsa", "qwerty"));
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+        // Add a new entry from our own interface.
+        hist.append("hjkl");
+        assertThat(hist.allEntries(),
+                   CoreMatchers.hasItems("asdf", "fdsa", "qwerty", "uiop", "hjkl"));
+        assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX),
+                   CoreMatchers.hasItems("fdsa", "qwerty", "uiop", "hjkl"));
+        // This one should not have changed.
+        assertThat(hist.entries(HIST_ENTRIES_FROM_INDEX, HIST_ENTRIES_TO_INDEX),
+                   CoreMatchers.hasItems("fdsa", "qwerty"));
     }
+
+    /**
+     * Tests the following methods: {@link JLine2InputHistory#getPrevious()},
+     * {@link JLine2InputHistory#getNext()} and {@link JLine2InputHistory#reset()}. called several
+     *
+     * @throws IOException
+     *             Should not happen.
+     */
+    @Test
+    public void testGetPrevious() throws IOException {
+        setUp("asdf" + ENTER + "fdsa" + ENTER + "qwerty" + ENTER);
+        // Getting the next item when there is none should return the empty string.
+        assertEquals("", hist.getNext());
+
+        assertEquals("qwerty", hist.getPrevious());
+        assertEquals("fdsa", hist.getPrevious());
+        assertEquals("asdf", hist.getPrevious());
+        // Getting the last item again should simply return the last item.
+        assertEquals("asdf", hist.getPrevious());
+
+        // After a reset, the first item should be returned again.
+        hist.reset();
+        assertEquals("qwerty", hist.getPrevious());
+
+        // Continue once more so that we can test getNext();
+        assertEquals("fdsa", hist.getPrevious());
+        assertEquals("qwerty", hist.getNext());
+        // Again, the empty string should be returned now.
+        assertEquals("", hist.getNext());
+    }
+
 }

--- a/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/impl/history/JLine2PersistentInputHistoryTest.java
+++ b/org.metaborg.spoofax.shell.console/src/test/java/org/metaborg/spoofax/shell/client/console/impl/history/JLine2PersistentInputHistoryTest.java
@@ -3,7 +3,6 @@ package org.metaborg.spoofax.shell.client.console.impl.history;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.metaborg.spoofax.shell.client.console.impl.TerminalUserInterfaceTest.ENTER;
 
 import java.io.File;
@@ -36,6 +35,7 @@ public class JLine2PersistentInputHistoryTest extends JLine2InputHistoryTest {
     @Before
     public void setUp() throws IOException {
         tempHistory = File.createTempFile("test_history", ".tmp");
+        tempHistory.deleteOnExit();
         setUp("asdf" + ENTER + "fdsa" + ENTER + ENTER);
     }
 
@@ -58,45 +58,43 @@ public class JLine2PersistentInputHistoryTest extends JLine2InputHistoryTest {
 
     /**
      * Tests the switch of the delegate before and after loading.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testDelegateSwitch() {
-        try {
-            assertEquals(theDelegate, systemUnderTest().delegate());
-            assertTrue(systemUnderTest().delegate() instanceof MemoryHistory);
-            systemUnderTest().loadFromDisk();
-            assertTrue(systemUnderTest().delegate() instanceof FileHistory);
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+    public void testDelegateSwitch() throws IOException {
+        assertEquals(theDelegate, systemUnderTest().delegate());
+        assertTrue(systemUnderTest().delegate() instanceof MemoryHistory);
+        systemUnderTest().loadFromDisk();
+        assertTrue(systemUnderTest().delegate() instanceof FileHistory);
     }
 
     /**
      * Tests persistence through creating a temporary file.
+     *
+     * @throws IOException
+     *             Should not happen.
      */
     @Test
-    public void testPersistentHistory() {
-        try {
-            assertThat(hist.allEntries(), CoreMatchers.hasItems("asdf", "fdsa"));
+    public void testPersistentHistory() throws IOException {
+        assertThat(hist.allEntries(), CoreMatchers.hasItems("asdf", "fdsa"));
 
-            // Now load entries from disk. The file is empty, so allEntries should still have all
-            // in-memory contents as before.
-            systemUnderTest().loadFromDisk();
-            assertThat(hist.allEntries(), CoreMatchers.hasItems("asdf", "fdsa"));
+        // Now load entries from disk. The file is empty, so allEntries should still have all
+        // in-memory contents as before.
+        systemUnderTest().loadFromDisk();
+        assertThat(hist.allEntries(), CoreMatchers.hasItems("asdf", "fdsa"));
 
-            hist.append("qwerty");
-            hist.append("hjkl");
+        hist.append("qwerty");
+        hist.append("hjkl");
 
-            // Persist to disk, check the file contents.
-            systemUnderTest().persistToDisk();
-            assertEquals("asdf\nfdsa\nqwerty\nhjkl\n", Files.toString(tempHistory, Charsets.UTF_8));
+        // Persist to disk, check the file contents.
+        systemUnderTest().persistToDisk();
+        assertEquals("asdf\nfdsa\nqwerty\nhjkl\n", Files.toString(tempHistory, Charsets.UTF_8));
 
-            // Load it back and check that the entries are there.
-            systemUnderTest().loadFromDisk();
-            assertThat(hist.allEntries(), CoreMatchers.hasItems("qwerty", "hjkl"));
-        } catch (IOException e) {
-            fail("Should not happen");
-        }
+        // Load it back and check that the entries are there.
+        systemUnderTest().loadFromDisk();
+        assertThat(hist.allEntries(), CoreMatchers.hasItems("qwerty", "hjkl"));
     }
 
 }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IInputHistory.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IInputHistory.java
@@ -17,6 +17,27 @@ public interface IInputHistory {
     void append(String newEntry);
 
     /**
+     * Get the previous, e.g. older, history entry. If the index is already at the oldest entry,
+     * that entry is simply returned again.
+     *
+     * @return The previous history entry.
+     */
+    String getPrevious();
+
+    /**
+     * Get the next, e.g. newer, history entry. If the index is already at the newest entry, an
+     * empty string should be returned.
+     *
+     * @return The next history entry.
+     */
+    String getNext();
+
+    /**
+     * Reset the current index used in {@link #getPrevious()} and {@link #getNext()}.
+     */
+    void reset();
+
+    /**
      * Get the most recent input history entry. Default implementation is equal to {@link #get(int)
      * get({@link #size()} - 1)}.
      *

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseEditor.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseEditor.java
@@ -15,7 +15,6 @@ import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
 import org.metaborg.spoofax.shell.client.IEditor;
 import org.metaborg.spoofax.shell.client.IInputHistory;
-import org.metaborg.spoofax.shell.client.eclipse.impl.history.EclipseInputHistory;
 
 import com.google.common.collect.Lists;
 import com.google.inject.assistedinject.Assisted;
@@ -94,8 +93,16 @@ public class EclipseEditor extends KeyAdapter implements ModifyListener {
         this.observers.remove(observer);
     }
 
+    private String removeLastNewline(String text) {
+        int length = text.length() - 1;
+        if (text.charAt(length) == '\n') {
+            text = text.substring(0, length);
+        }
+        return text;
+    }
+
     private void enterPressed() {
-        String text = document.get();
+        String text = removeLastNewline(document.get());
         this.observers.forEach(o -> o.onNext(text));
         if (text.length() > 0) {
             this.history.append(text);

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseInputHistory.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseInputHistory.java
@@ -1,4 +1,4 @@
-package org.metaborg.spoofax.shell.client.eclipse.impl.history;
+package org.metaborg.spoofax.shell.client.eclipse.impl;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseReplModule.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseReplModule.java
@@ -1,7 +1,9 @@
 package org.metaborg.spoofax.shell.client.eclipse.impl;
 
+import org.metaborg.spoofax.shell.client.IInputHistory;
 import org.metaborg.spoofax.shell.client.ReplModule;
 import org.metaborg.spoofax.shell.client.eclipse.ColorManager;
+import org.metaborg.spoofax.shell.client.eclipse.impl.history.EclipseInputHistory;
 
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
@@ -17,6 +19,7 @@ public class EclipseReplModule extends ReplModule {
 
         // Singleton so that all REPLs talk to the same ColorManager.
         bind(ColorManager.class).in(Singleton.class);
+        bind(IInputHistory.class).to(EclipseInputHistory.class);
         install(new FactoryModuleBuilder().build(IWidgetFactory.class));
     }
 }

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseReplModule.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseReplModule.java
@@ -3,7 +3,6 @@ package org.metaborg.spoofax.shell.client.eclipse.impl;
 import org.metaborg.spoofax.shell.client.IInputHistory;
 import org.metaborg.spoofax.shell.client.ReplModule;
 import org.metaborg.spoofax.shell.client.eclipse.ColorManager;
-import org.metaborg.spoofax.shell.client.eclipse.impl.history.EclipseInputHistory;
 
 import com.google.inject.Singleton;
 import com.google.inject.assistedinject.FactoryModuleBuilder;

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/history/EclipseInputHistory.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/history/EclipseInputHistory.java
@@ -1,0 +1,68 @@
+package org.metaborg.spoofax.shell.client.eclipse.impl.history;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import org.metaborg.spoofax.shell.client.IInputHistory;
+
+/**
+ * A volatile Eclipse-based implementation of {@link IInputHistory}. This implementation is backed
+ * by a {@link LinkedList}.
+ */
+public class EclipseInputHistory implements IInputHistory {
+    private final List<String> history;
+    private int index;
+
+    /**
+     * Instantiate a new EclipseHistory.
+     */
+    public EclipseInputHistory() {
+        this.history = new LinkedList<>();
+        reset();
+    }
+
+    @Override
+    public void append(String newEntry) {
+        this.history.add(newEntry);
+    }
+
+    private String current() {
+        if (this.index >= size()) {
+            return "";
+        }
+        return this.history.get(this.index);
+    }
+
+    @Override
+    public String getPrevious() {
+        if (this.index <= 0) {
+            return current();
+        }
+        this.index -= 1;
+        return current();
+    }
+
+    @Override
+    public String getNext() {
+        if (this.index >= size()) {
+            return current();
+        }
+        this.index += 1;
+        return current();
+    }
+
+    @Override
+    public void reset() {
+        this.index = size();
+    }
+
+    @Override
+    public int size() {
+        return this.history.size();
+    }
+
+    @Override
+    public List<String> entries(int from, int to) {
+        return this.history.subList(from, to);
+    }
+}


### PR DESCRIPTION
Branched from #31. This PR provides an Eclipse-implementation of `IInputHistory`. I added three stateful methods to this interface to move the index-logic from `EclipseEditor` to `EclipseInputHistory`.

I also took the liberty of fixing an outstanding FIXME in `EclipseEditor`.

@gfokkema Do you know if we can do better than what I did in 9c26d5aea5da3b36d2faf292c82ff7dad6f83840?
