### PR TITLE
[RDY] Also catch all RuntimeExceptions coming from DynSem and Spoofax

### DIFF
--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleRepl.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleRepl.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import org.metaborg.spoofax.shell.client.IDisplay;
 import org.metaborg.spoofax.shell.client.IRepl;
-import org.metaborg.spoofax.shell.invoker.CommandNotFoundException;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 
 import com.google.inject.Inject;
@@ -58,11 +57,7 @@ public class ConsoleRepl implements IRepl {
      *            The input to evaluate.
      */
     public void runOnce(String input) {
-        try {
-            eval(input).accept(display);
-        } catch (CommandNotFoundException e) {
-            this.display.visitException(e);
-        }
+        eval(input).accept(display);
     }
 
     /**

--- a/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleRepl.java
+++ b/org.metaborg.spoofax.shell.console/src/main/java/org/metaborg/spoofax/shell/client/console/impl/ConsoleRepl.java
@@ -1,13 +1,11 @@
 package org.metaborg.spoofax.shell.client.console.impl;
 
-import java.awt.Color;
 import java.io.IOException;
 
 import org.metaborg.spoofax.shell.client.IDisplay;
 import org.metaborg.spoofax.shell.client.IRepl;
 import org.metaborg.spoofax.shell.invoker.CommandNotFoundException;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
-import org.metaborg.spoofax.shell.output.StyledText;
 
 import com.google.inject.Inject;
 
@@ -63,7 +61,7 @@ public class ConsoleRepl implements IRepl {
         try {
             eval(input).accept(display);
         } catch (CommandNotFoundException e) {
-            this.display.displayStyledText(new StyledText(Color.RED, e.getMessage()));
+            this.display.visitException(e);
         }
     }
 
@@ -85,7 +83,7 @@ public class ConsoleRepl implements IRepl {
 
             this.iface.history().persistToDisk();
         } catch (IOException e) {
-            this.display.displayStyledText(new StyledText(Color.RED, e.getMessage()));
+            this.display.visitException(e);
         }
     }
 

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IRepl.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/client/IRepl.java
@@ -3,6 +3,7 @@ package org.metaborg.spoofax.shell.client;
 import org.metaborg.spoofax.shell.commands.IReplCommand;
 import org.metaborg.spoofax.shell.invoker.CommandNotFoundException;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
+import org.metaborg.spoofax.shell.output.ExceptionResult;
 import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.IResultVisitor;
 
@@ -26,16 +27,19 @@ public interface IRepl {
      * @return An {@link IResult} to process the result of the evaluation. When the input is empty,
      *         it returns an {@link IResult} that does nothing upon accepting a
      *         {@link IResultVisitor visitor}.
-     * @throws CommandNotFoundException
-     *             When the command could not be found.
      */
-    default IResult eval(String input) throws CommandNotFoundException {
+    default IResult eval(String input) {
         input = input.trim();
         if (input.length() == 0) {
             return (visitor) -> {
             };
         }
-        return getInvoker().execute(input);
+
+        try {
+            return getInvoker().execute(input);
+        } catch (CommandNotFoundException e) {
+            return new ExceptionResult(e);
+        }
     }
 
     /**

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/LanguageCommand.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/commands/LanguageCommand.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import org.apache.commons.vfs2.FileObject;
 import org.metaborg.core.MetaborgException;
+import org.metaborg.core.MetaborgRuntimeException;
 import org.metaborg.core.action.ITransformAction;
 import org.metaborg.core.analysis.AnalyzerFacet;
 import org.metaborg.core.language.ILanguageComponent;
@@ -141,7 +142,7 @@ public class LanguageCommand implements IReplCommand {
             loadCommands(lang);
 
             return (visitor) -> visitor.visitMessage(new StyledText("Loaded language " + lang));
-        } catch (MetaborgException e) {
+        } catch (MetaborgException | MetaborgRuntimeException e) {
             return new ExceptionResult(e);
         }
     }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/core/DynSemEvaluationStrategy.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/core/DynSemEvaluationStrategy.java
@@ -151,7 +151,7 @@ public class DynSemEvaluationStrategy implements IEvaluationStrategy {
     }
 
     private boolean uninitialized() {
-        return polyglotEngine == null;
+        return polyglotEngine == null || rwSemanticComponents == null;
     }
 
     private void initialize(ILanguageImpl langImpl) throws InterpreterLoadException {

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/AbstractSpoofaxFunction.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/AbstractSpoofaxFunction.java
@@ -60,8 +60,6 @@ public abstract class AbstractSpoofaxFunction<In, Success extends ISpoofaxResult
     public FailOrSuccessResult<Success, IResult> apply(In a) {
         try {
             return this.applyThrowing(a);
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
             return FailOrSuccessResult.failed(new ExceptionResult(e));
         }

--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/StyledText.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/output/StyledText.java
@@ -141,16 +141,16 @@ public class StyledText {
     public StyledText append(Iterable<ISourceRegion> regions, IStyle style, String text) {
         RangeSet<Integer> rangeSet = TreeRangeSet.create();
         StreamSupport.stream(regions.spliterator(), false)
-            .map(r -> Range.closed(r.startOffset(), r.endOffset())).forEach(rangeSet::add);
+            .map(r -> Range.closed(r.startOffset(), r.endOffset() + 1)).forEach(rangeSet::add);
         List<Range<Integer>> sortedRanges = rangeSet.asRanges().stream()
             .sorted((a, b) -> a.lowerEndpoint() - b.lowerEndpoint()).collect(Collectors.toList());
         int curOffset = 0;
         for (Range<Integer> r : sortedRanges) {
             String sub = text.substring(curOffset, r.lowerEndpoint());
             this.append(sub);
-            String errorRegion = text.substring(r.lowerEndpoint(), r.upperEndpoint() + 1);
+            String errorRegion = text.substring(r.lowerEndpoint(), r.upperEndpoint());
             this.append(style, errorRegion);
-            curOffset = r.upperEndpoint() + 1;
+            curOffset = r.upperEndpoint();
         }
         // Add the rest.
         this.append(text.substring(curOffset));

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
@@ -32,7 +32,7 @@ import rx.Observer;
 public class EclipseRepl implements IRepl, Observer<String> {
     private final IDisplay display;
     private final ICommandInvoker invoker;
-    private ExecutorService pool;
+    private final ExecutorService pool;
 
     /**
      * Instantiates a new EclipseRepl.

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/impl/EclipseRepl.java
@@ -12,7 +12,6 @@ import org.eclipse.ui.progress.UIJob;
 import org.metaborg.core.style.Style;
 import org.metaborg.spoofax.shell.client.IDisplay;
 import org.metaborg.spoofax.shell.client.IRepl;
-import org.metaborg.spoofax.shell.invoker.CommandNotFoundException;
 import org.metaborg.spoofax.shell.invoker.ICommandInvoker;
 import org.metaborg.spoofax.shell.output.IResult;
 import org.metaborg.spoofax.shell.output.StyledText;
@@ -89,16 +88,7 @@ public class EclipseRepl implements IRepl, Observer<String> {
             @Override
             protected IStatus run(IProgressMonitor monitor) {
                 try {
-                    IResult result = pool.submit(() -> {
-                        IResult eval;
-                        try {
-                            eval = eval(input);
-                        } catch (CommandNotFoundException e) {
-                            eval = (visitor) -> visitor.visitException(e);
-                        }
-                        return eval;
-                    }).get();
-
+                    IResult result = pool.submit(() -> eval(input)).get();
                     runAsUIJob(result);
                     return Status.OK_STATUS;
                 } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
All CheckedExceptions were already caught by the FailableFunctions.
During the demo the REPL was mostly crashing on RuntimeExceptions that do not extend MetaborgException (and therefore were not caught).
