### PR TITLE
[RDY] Use rule lookup method for checking non-existing rules

### DIFF
--- a/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/AbstractSpoofaxFunction.java
+++ b/org.metaborg.spoofax.shell.core/src/main/java/org/metaborg/spoofax/shell/functions/AbstractSpoofaxFunction.java
@@ -60,8 +60,6 @@ public abstract class AbstractSpoofaxFunction<In, Success extends ISpoofaxResult
     public FailOrSuccessResult<Success, IResult> apply(In a) {
         try {
             return this.applyThrowing(a);
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
             return FailOrSuccessResult.failed(new ExceptionResult(e));
         }


### PR DESCRIPTION
This provides a proper error message when the init rule was not found. Include a test case for a non-existing `ShellInit` rule.
