### PR TITLE
[PoC] Add "Run in REPL" menu contribution

### DIFF
--- a/org.metaborg.spoofax.shell.eclipse/META-INF/MANIFEST.MF
+++ b/org.metaborg.spoofax.shell.eclipse/META-INF/MANIFEST.MF
@@ -4,14 +4,16 @@ Bundle-Name: Spoofax Eclipse REPL
 Bundle-SymbolicName: org.metaborg.spoofax.shell.eclipse;singleton:=true
 Bundle-Version: 0.0.4.qualifier
 Bundle-Activator: org.metaborg.spoofax.shell.client.eclipse.Activator
-Require-Bundle: org.eclipse.core.runtime;bundle-version="3.11.1",
+Require-Bundle: org.eclipse.core.resources;bundle-version="3.10.1",
+ org.eclipse.core.runtime;bundle-version="3.11.1",
  org.eclipse.jface.text;bundle-version="3.10.0",
  org.eclipse.ui;bundle-version="3.107.0",
  org.metaborg.core;bundle-version="2.0.0",
  org.metaborg.spoofax.core;bundle-version="2.0.0",
  org.metaborg.spoofax.shell.core;bundle-version="0.0.4",
  org.metaborg.spoofax.shell.eclipse.externaldeps;bundle-version="0.0.4",
- org.metaborg.spoofax.eclipse.externaldeps;bundle-version="2.0.0"
+ org.metaborg.spoofax.eclipse.externaldeps;bundle-version="2.0.0",
+ org.metaborg.spoofax.eclipse.util;bundle-version="2.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-Vendor: metaborg.org
 Export-Package: org.metaborg.spoofax.shell.client.eclipse,

--- a/org.metaborg.spoofax.shell.eclipse/plugin.xml
+++ b/org.metaborg.spoofax.shell.eclipse/plugin.xml
@@ -13,4 +13,36 @@
            class="org.metaborg.spoofax.shell.client.eclipse.ReplView"/>
     </extension>
 
+    <extension point="org.eclipse.ui.commands">
+        <!-- "Run REPL" command -->
+        <command id="org.metaborg.spoofax.shell.client.eclipse.handlers.meta.run" name="Run in REPL"/>
+    </extension>
+    <extension point="org.eclipse.ui.handlers">
+        <handler commandId="org.metaborg.spoofax.shell.client.eclipse.handlers.meta.run"
+                     class="org.metaborg.spoofax.shell.client.eclipse.handlers.MetaRunHandler"/>
+    </extension>
+
+    <extension point="org.eclipse.ui.menus">
+        <!-- Menu item in "Spoofax (meta)" submenu. -->
+        <menuContribution locationURI="menu:org.metaborg.spoofax.eclipse.meta.menu.main">
+            <command commandId="org.metaborg.spoofax.shell.client.eclipse.handlers.meta.run"
+                         label="Run in REPL"
+                       tooltip="Launch the current language in the REPL">
+                <visibleWhen>
+                    <reference definitionId="org.metaborg.spoofax.eclipse.meta.expression.hasnature"/>
+                </visibleWhen>
+            </command>
+        </menuContribution>
+        <!-- Menu item in the project context menu (package- and project explorer). -->
+        <menuContribution locationURI="popup:org.metaborg.spoofax.eclipse.meta.menu.project">
+            <command commandId="org.metaborg.spoofax.shell.client.eclipse.handlers.meta.run"
+                         label="Run in REPL"
+                       tooltip="Launch the current language in the REPL">
+                <visibleWhen>
+                    <reference definitionId="org.metaborg.spoofax.eclipse.meta.expression.hasnature"/>
+                </visibleWhen>
+            </command>
+        </menuContribution>
+    </extension>
+
 </plugin>

--- a/org.metaborg.spoofax.shell.eclipse/pom.xml
+++ b/org.metaborg.spoofax.shell.eclipse/pom.xml
@@ -36,6 +36,11 @@
     <dependencies>
         <dependency>
             <groupId>org.metaborg</groupId>
+            <artifactId>org.metaborg.spoofax.eclipse.util</artifactId>
+            <version>${metaborg-version}</version>
+         </dependency>
+         <dependency>
+            <groupId>org.metaborg</groupId>
             <artifactId>org.metaborg.spoofax.shell.core</artifactId>
             <version>0.0.4-SNAPSHOT</version>
         </dependency>

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/ReplView.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/ReplView.java
@@ -17,9 +17,11 @@ import com.google.inject.Injector;
  * Eclipse as a singleton, at most one ReplView will be active at any given time.
  */
 public class ReplView extends ViewPart {
+    public static final String ID = Activator.getPluginID() + ".view";
     private static final int DISPLAYWEIGHT = 5;
     private static final int EDITORWEIGHT = 1;
     private EclipseEditor editor;
+    private EclipseRepl repl;
     private ColorManager colorManager;
 
     @Override
@@ -36,11 +38,20 @@ public class ReplView extends ViewPart {
         page.setWeights(new int[] { DISPLAYWEIGHT, EDITORWEIGHT });
 
         // Instantiate the REPL and add it as observer of the editor.
-        EclipseRepl repl = factory.createRepl(display);
+        this.repl = factory.createRepl(display);
         this.editor.asObservable().subscribe(repl);
 
         // Retrieve the color manager so that it can be disposed of when the view is closed.
         this.colorManager = injector.getInstance(ColorManager.class);
+    }
+
+    /**
+     * Return the currently active {@link EclipseRepl}.
+     *
+     * @return The currently active {@link EclipseRepl.
+     */
+    public EclipseRepl getRepl() {
+        return this.repl;
     }
 
     @Override

--- a/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/handlers/MetaRunHandler.java
+++ b/org.metaborg.spoofax.shell.eclipse/src/main/java/org/metaborg/spoofax/shell/client/eclipse/handlers/MetaRunHandler.java
@@ -1,0 +1,83 @@
+package org.metaborg.spoofax.shell.client.eclipse.handlers;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IHandler;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Shell;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.metaborg.spoofax.eclipse.util.AbstractHandlerUtils;
+import org.metaborg.spoofax.shell.client.eclipse.ReplView;
+import org.metaborg.spoofax.shell.client.eclipse.impl.EclipseRepl;
+
+/**
+ * An {@link IHandler} implementation for the "Run in REPL" Spoofax (meta) menu. This handler will
+ * run the project currently open in Spoofax Eclipse in a REPL session. It is up to the language
+ * designer to build the project before running it.
+ */
+public class MetaRunHandler extends AbstractHandler {
+
+    // TODO: either always build the language or ask the user, but the option to build the language
+    // should be here!
+
+    @Override
+    public Object execute(ExecutionEvent event) throws ExecutionException {
+        IWorkbenchWindow window = HandlerUtil.getActiveWorkbenchWindow(event);
+        IWorkbenchPage page = window.getActivePage();
+        Shell shell = window.getShell();
+
+        if (replaceRunningRepl(page, shell)) {
+            openReplSession(page, shell, event);
+        }
+
+        // Must always return null.
+        return null;
+    }
+
+    private boolean replaceRunningRepl(IWorkbenchPage page, Shell shell) {
+        if (page.findView(ReplView.ID) != null) {
+            return MessageDialog.openConfirm(shell, "Only one REPL session can run at a time",
+                                             "Continuing will replace the current REPL session");
+        }
+        return true;
+    }
+
+    private void openReplSession(IWorkbenchPage page, Shell shell, ExecutionEvent event) {
+        try {
+            ReplView view = (ReplView) page.showView(ReplView.ID);
+            EclipseRepl repl = view.getRepl();
+
+            // Naive but simple way to load a new language.
+            String language = getLanguage(event);
+            if (language != null) {
+                repl.onNext(":load " + language);
+            } else {
+                MessageDialog.openError(shell, "Something went wrong",
+                                        "Could not find the language implementation project");
+            }
+        } catch (PartInitException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // TODO: use "eclipse://" instead of absolute paths?
+    // TODO: be able to handle more selections, such that the user is not required to click on the
+    // project in the project explorer first when using the menu contribution.
+    private String getLanguage(ExecutionEvent event) {
+        // We can assume this is a Spoofax language project, as the "Run in REPL" menu item
+        // only shows on projects that have the Spoofax meta nature (of course, one can manually add
+        // said nature to a Java project, but hey, if you want to break things you get to keep the
+        // pieces).
+        IProject project = AbstractHandlerUtils.toProject(event);
+        if (project == null) {
+            return null;
+        }
+        return project.getLocation().toOSString();
+    }
+
+}


### PR DESCRIPTION
The "Run in REPL" button needs to be able to build the current language. Also, retrieving the active project from the `ExecutionEvent` could be done better.
